### PR TITLE
add is() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ the **nil** marker
 
 ## API
 
-### encode(input)
+### `encode(input)`
 
 Takes any JavaScript primitive and returns its encoded counterpart. Is applied
 recursively in case the input is an object or an array. All inputs are converted
 to [TFD] Buffers, except for objects, arrays, and numbers, which remain the
 same.
 
-### decode(input)
+### `decode(input)`
 
 Takes an encoded value (such as the output from `encode`) and returns the
 decoded counterparts as JavaScript primitives.
 
-### bfeTypes
+### `bfeTypes`
 
 Returns the `bfe.json` object that can be used to look up information
 based on Type and Field. Example:
@@ -48,18 +48,18 @@ const { bfeTypes } = require('ssb-bfe')
 const classic_key_size = bfeTypes[0][0].data_length
 ```
 
-### bfeNamedTypes
+### `bfeNamedTypes`
 
 Returns the `bfe.json` object converted to a map where the keys are
 the type and format names. Example:
 
-```
+```js
 const { bfeNamedTypes } = require('ssb-bfe')
 const FEED = bfeNamedTypes['feed']
 const CLASSIC_FEED_TF = Buffer.from([FEED.code, FEED.formats['classic'].code])
 ```
 
-### toTF(typeName, formatName)
+### `toTF(typeName, formatName)`
 
 Sometimes when you're wanting to check what sort of buffer you're handling, you want
 to pivot on the type and format bytes.
@@ -79,6 +79,51 @@ const CLASSIC_MSG_TF = bfe.toTF('msg', 'classic')
 
 If you remembered the type or format name wrong, you'll instantly get an error!
 
+### Check whether a buffer is an encoded type
+
+Given any input, these functions tell you whether the input is of the specified
+type (and format, if applicable). Example:
+
+```js
+const bfe = require('ssb-bfe')
+
+const x = bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+
+bfe.isEncodedFeedClassic(x) // true
+```
+
+List of functions:
+
+- `isEncodedFeed(input) => boolean`
+- `isEncodedFeedClassic(input) => boolean`
+- `isEncodedFeedGabbygroveV1(input) => boolean`
+- `isEncodedFeedBamboo(input) => boolean`
+- `isEncodedFeedBendybuttV1(input) => boolean`
+- `isEncodedFeedButtwooV1(input) => boolean`
+- `isEncodedMessage(input) => boolean`
+- `isEncodedMessageClassic(input) => boolean`
+- `isEncodedMessageGabbygroveV1(input) => boolean`
+- `isEncodedMessageCloaked(input) => boolean`
+- `isEncodedMessageBamboo(input) => boolean`
+- `isEncodedMessageBendybuttV1(input) => boolean`
+- `isEncodedMessageButtwooV1(input) => boolean`
+- `isEncodedBlob(input) => boolean`
+- `isEncodedBlobClassic(input) => boolean`
+- `isEncodedEncryptionKey(input) => boolean`
+- `isEncodedEncryptionKeyBox2DmDh(input) => boolean`
+- `isEncodedEncryptionKeyBox2PoboxDh(input) => boolean`
+- `isEncodedSignature(input) => boolean`
+- `isEncodedSignatureMsgEd25519(input) => boolean`
+- `isEncodedEncrypted(input) => boolean`
+- `isEncodedEncryptedBox1(input) => boolean`
+- `isEncodedEncryptedBox2(input) => boolean`
+- `isEncodedGeneric(input) => boolean`
+- `isEncodedGenericStringUTF8(input) => boolean`
+- `isEncodedGenericBoolean(input) => boolean`
+- `isEncodedGenericNil(input) => boolean`
+- `isEncodedGenericAnyBytes(input) => boolean`
+- `isEncodedIdentity(input) => boolean`
+- `isEncodedIdentityPoBox(input) => boolean`
 
 
 [ssb binary field encodings]: https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec

--- a/test/is.js
+++ b/test/is.js
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+//
+// SPDX-License-Identifier: Unlicense
+
+const tape = require('tape')
+const bfe = require('../')
+
+tape('enumerate all is*() helpers', function (t) {
+  t.equals(typeof bfe.isEncodedFeed, 'function')
+  t.equals(typeof bfe.isEncodedFeedClassic, 'function')
+  t.equals(typeof bfe.isEncodedFeedGabbygroveV1, 'function')
+  t.equals(typeof bfe.isEncodedFeedBamboo, 'function')
+  t.equals(typeof bfe.isEncodedFeedBendybuttV1, 'function')
+  t.equals(typeof bfe.isEncodedFeedButtwooV1, 'function')
+  t.equals(typeof bfe.isEncodedMessage, 'function')
+  t.equals(typeof bfe.isEncodedMessageClassic, 'function')
+  t.equals(typeof bfe.isEncodedMessageGabbygroveV1, 'function')
+  t.equals(typeof bfe.isEncodedMessageCloaked, 'function')
+  t.equals(typeof bfe.isEncodedMessageBamboo, 'function')
+  t.equals(typeof bfe.isEncodedMessageBendybuttV1, 'function')
+  t.equals(typeof bfe.isEncodedMessageButtwooV1, 'function')
+  t.equals(typeof bfe.isEncodedBlob, 'function')
+  t.equals(typeof bfe.isEncodedBlobClassic, 'function')
+  t.equals(typeof bfe.isEncodedEncryptionKey, 'function')
+  t.equals(typeof bfe.isEncodedEncryptionKeyBox2DmDh, 'function')
+  t.equals(typeof bfe.isEncodedEncryptionKeyBox2PoboxDh, 'function')
+  t.equals(typeof bfe.isEncodedSignature, 'function')
+  t.equals(typeof bfe.isEncodedSignatureMsgEd25519, 'function')
+  t.equals(typeof bfe.isEncodedEncrypted, 'function')
+  t.equals(typeof bfe.isEncodedEncryptedBox1, 'function')
+  t.equals(typeof bfe.isEncodedEncryptedBox2, 'function')
+  t.equals(typeof bfe.isEncodedGeneric, 'function')
+  t.equals(typeof bfe.isEncodedGenericStringUTF8, 'function')
+  t.equals(typeof bfe.isEncodedGenericBoolean, 'function')
+  t.equals(typeof bfe.isEncodedGenericNil, 'function')
+  t.equals(typeof bfe.isEncodedGenericAnyBytes, 'function')
+  t.equals(typeof bfe.isEncodedIdentity, 'function')
+  t.equals(typeof bfe.isEncodedIdentityPoBox, 'function')
+  t.end()
+})
+
+tape('isEncodedFeed*() happy cases', function (t) {
+  t.true(
+    bfe.isEncodedFeed(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedFeed classic'
+  )
+  t.true(
+    bfe.isEncodedFeed(
+      bfe.encode(
+        'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0='
+      )
+    ),
+    'isEncodedFeed bendybutt-v1'
+  )
+  t.true(
+    bfe.isEncodedFeed(
+      bfe.encode(
+        'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedFeed gabbygrove-v1'
+  )
+  t.true(
+    bfe.isEncodedFeed(
+      bfe.encode(
+        'ssb:feed/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedFeed buttwoo-v1'
+  )
+
+  t.true(
+    bfe.isEncodedFeedClassic(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedFeedClassic'
+  )
+  t.true(
+    bfe.isEncodedFeedBendybuttV1(
+      bfe.encode(
+        'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0='
+      )
+    ),
+    'isEncodedFeedBendyButtV1'
+  )
+  t.true(
+    bfe.isEncodedFeedGabbygroveV1(
+      bfe.encode(
+        'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedFeedGabbyGroveV1'
+  )
+  t.true(
+    bfe.isEncodedFeedButtwooV1(
+      bfe.encode(
+        'ssb:feed/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedFeedButtwooV1'
+  )
+
+  t.end()
+})
+
+tape('isEncodedFeed*() sad cases', function (t) {
+  t.false(
+    bfe.isEncodedFeed(
+      bfe.encode('%6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.sha256')
+    ),
+    'isEncodedFeed invalid type'
+  )
+  t.false(
+    bfe.isEncodedFeed(bfe.encode('@6CAxOI3f+LUOVrbw9LC4+Uv0=.ed25519')),
+    'isEncodedFeed classic wrong length'
+  )
+  t.false(
+    bfe.isEncodedFeedBendybuttV1(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedFeedBendyButtV1 classic'
+  )
+  t.false(
+    bfe.isEncodedFeedGabbygroveV1(
+      bfe.encode(
+        'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0='
+      )
+    ),
+    'isEncodedFeedGabbyGroveV1 bendybutt-v1'
+  )
+  t.false(
+    bfe.isEncodedFeedButtwooV1(
+      bfe.encode(
+        'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedFeedButtwooV1 gabbygrove-v1'
+  )
+  t.false(
+    bfe.isEncodedFeedClassic(
+      bfe.encode(
+        'ssb:feed/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedFeedClassic buttwoo-v1'
+  )
+
+  t.end()
+})
+
+tape('isEncodedMessage*() happy cases', function (t) {
+  t.true(
+    bfe.isEncodedMessage(
+      bfe.encode('%6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.sha256')
+    ),
+    'isEncodedMessage classic'
+  )
+  t.true(
+    bfe.isEncodedMessage(
+      bfe.encode(
+        'ssb:message/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0='
+      )
+    ),
+    'isEncodedMessage bendybutt-v1'
+  )
+  t.true(
+    bfe.isEncodedMessage(
+      bfe.encode(
+        'ssb:message/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedMessage gabbygrove-v1'
+  )
+  t.true(
+    bfe.isEncodedMessage(
+      bfe.encode(
+        'ssb:message/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedMessage buttwoo-v1'
+  )
+
+  t.true(
+    bfe.isEncodedMessageClassic(
+      bfe.encode('%6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.sha256')
+    ),
+    'isEncodedMessageClassic'
+  )
+  t.true(
+    bfe.isEncodedMessageBendybuttV1(
+      bfe.encode(
+        'ssb:message/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0='
+      )
+    ),
+    'isEncodedMessageBendyButtV1'
+  )
+  t.true(
+    bfe.isEncodedMessageGabbygroveV1(
+      bfe.encode(
+        'ssb:message/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedMessageGabbyGroveV1'
+  )
+  t.true(
+    bfe.isEncodedMessageButtwooV1(
+      bfe.encode(
+        'ssb:message/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedMessageButtwooV1'
+  )
+
+  t.end()
+})
+
+tape('isEncodedMessage*() sad cases', function (t) {
+  t.false(
+    bfe.isEncodedMessage(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedMessage invalid type'
+  )
+  t.false(
+    bfe.isEncodedMessage(bfe.encode('%6CAxOI3f+LUOVrbw9LC4+Uv0=.sha256')),
+    'isEncodedMessage classic wrong length'
+  )
+  t.false(
+    bfe.isEncodedMessageBendybuttV1(
+      bfe.encode('%6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.sha256')
+    ),
+    'isEncodedMessageBendyButtV1 classic'
+  )
+  t.false(
+    bfe.isEncodedMessageGabbygroveV1(
+      bfe.encode(
+        'ssb:message/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0='
+      )
+    ),
+    'isEncodedMessageGabbyGroveV1 bendybutt-v1'
+  )
+  t.false(
+    bfe.isEncodedMessageButtwooV1(
+      bfe.encode(
+        'ssb:message/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedMessageButtwooV1 gabbygrove-v1'
+  )
+  t.false(
+    bfe.isEncodedMessageClassic(
+      bfe.encode(
+        'ssb:message/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ='
+      )
+    ),
+    'isEncodedMessageClassic buttwoo-v1'
+  )
+
+  t.end()
+})
+
+tape('isEncodedBlob*() happy cases', function (t) {
+  t.true(
+    bfe.isEncodedBlob(
+      bfe.encode('&s7+cwhm6dz9si5vn4ftpk/l/ldbrmqzzjos+spzbwf4=.sha256')
+    ),
+    'isEncodedBlob classic'
+  )
+  t.true(
+    bfe.isEncodedBlobClassic(
+      bfe.encode('&s7+cwhm6dz9si5vn4ftpk/l/ldbrmqzzjos+spzbwf4=.sha256')
+    ),
+    'isEncodedBlobClassic'
+  )
+
+  t.end()
+})
+
+tape('isEncodedBlob*() sad cases', function (t) {
+  t.false(
+    bfe.isEncodedBlob(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedBlob invalid type'
+  )
+  t.false(
+    bfe.isEncodedBlob(bfe.encode('&s7+cwhm6dz9si5vn4ftqzzjos+spzbwf4=.sha256')),
+    'isEncodedBlob classic wrong length'
+  )
+  t.false(
+    bfe.isEncodedBlobClassic(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedBlobClassic invalid type'
+  )
+
+  t.end()
+})
+
+tape('isEncodedGeneric*() happy cases', function (t) {
+  t.true(bfe.isEncodedGeneric(bfe.encode('hello'), 'isEncodedGeneric string'))
+  t.true(
+    bfe.isEncodedGenericStringUTF8(
+      bfe.encode('hello'),
+      'isEncodedGenericStringUTF8'
+    )
+  )
+  t.true(
+    bfe.isEncodedGenericBoolean(bfe.encode(true), 'isEncodedGenericBoolean')
+  )
+  t.true(bfe.isEncodedGenericNil(bfe.encode(null), 'isEncodedGenericNil'))
+  t.true(
+    bfe.isEncodedGenericAnyBytes(
+      bfe.encode(Buffer.from([3, 2, 1])),
+      'isEncodedGenericAnyBytes'
+    )
+  )
+
+  t.end()
+})
+
+tape('isEncodedGeneric*() sad cases', function (t) {
+  t.false(
+    bfe.isEncodedGeneric(
+      bfe.encode('@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519')
+    ),
+    'isEncodedGeneric invalid type'
+  )
+  t.false(
+    bfe.isEncodedGenericBoolean(bfe.encode(null)),
+    'isEncodedGenericBoolean null'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
## Problem

There are a couple other modules that use ssb-bfe like this:

```js
const FEED = bfe.bfeNamedTypes['feed']
const CLASSIC_FEED_TF = Buffer.from([FEED.code, FEED.formats['classic'].code])
if (feedId.slice(0, 2).equals(CLASSIC_FEED_TF))
```

That's kind of sad, we have to build a bunch of Buffer and slice buffers and stuff just to know if `feedId` is an encoded BFE of the type "feed". It's also error prone to fiddle with buffers like that, untested.

## Solution

Similar to `ssb-uri2` has `isGabbyGroveV1MessageSSBURI(input) => boolean`, there are now:

- `isEncodedFeed(input) => boolean`
- `isEncodedFeedClassic(input) => boolean`
- `isEncodedFeedGabbygroveV1(input) => boolean`
- `isEncodedFeedBamboo(input) => boolean`
- `isEncodedFeedBendybuttV1(input) => boolean`
- `isEncodedFeedButtwooV1(input) => boolean`
- `isEncodedMessage(input) => boolean`
- `isEncodedMessageClassic(input) => boolean`
- `isEncodedMessageGabbygroveV1(input) => boolean`
- `isEncodedMessageCloaked(input) => boolean`
- `isEncodedMessageBamboo(input) => boolean`
- `isEncodedMessageBendybuttV1(input) => boolean`
- `isEncodedMessageButtwooV1(input) => boolean`
- `isEncodedBlob(input) => boolean`
- `isEncodedBlobClassic(input) => boolean`
- `isEncodedEncryptionKey(input) => boolean`
- `isEncodedEncryptionKeyBox2DmDh(input) => boolean`
- `isEncodedEncryptionKeyBox2PoboxDh(input) => boolean`
- `isEncodedSignature(input) => boolean`
- `isEncodedSignatureMsgEd25519(input) => boolean`
- `isEncodedEncrypted(input) => boolean`
- `isEncodedEncryptedBox1(input) => boolean`
- `isEncodedEncryptedBox2(input) => boolean`
- `isEncodedGeneric(input) => boolean`
- `isEncodedGenericStringUTF8(input) => boolean`
- `isEncodedGenericBoolean(input) => boolean`
- `isEncodedGenericNil(input) => boolean`
- `isEncodedGenericAnyBytes(input) => boolean`
- `isEncodedIdentity(input) => boolean`
- `isEncodedIdentityPoBox(input) => boolean`

such that the input is a buffer and you get a boolean answering you that the type/format is the thing.

## Details

I started implementing this manually, like `isEncodedFeedClassic` implemented by hand, etc. Half the way I figured this is stupid. There is way too many cases, and when we update ssb-bfe-spec we will have to manually update ssb-bfe.

So instead I found a way of using bfe.json from ssb-bfe-spec to automatically create these functions. Should fit the style of this library which doesn't manually list all the types/formats, but instead uses `TYPES` and `NAMED_TYPES`.