### PR TITLE
update ssb-uri2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "is-canonical-base64": "^1.1.1",
     "ssb-bfe-spec": "~0.6.0",
     "ssb-ref": "^2.16.0",
-    "ssb-uri2": "^2.0.0"
+    "ssb-uri2": "^1.9.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "is-canonical-base64": "^1.1.1",
     "ssb-bfe-spec": "~0.6.0",
     "ssb-ref": "^2.16.0",
-    "ssb-uri2": "^1.9.0"
+    "ssb-uri2": "^2.0.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "LICENSES/*"
   ],
   "scripts": {
-    "test": "tape test/*.js | tap-bail | tap-spec",
+    "test": "tape test/*.js | tap-arc --bail",
     "coverage": "nyc --reporter=lcov npm test",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\""
@@ -23,15 +23,14 @@
     "is-canonical-base64": "^1.1.1",
     "ssb-bfe-spec": "~0.6.0",
     "ssb-ref": "^2.16.0",
-    "ssb-uri2": "^1.8.1"
+    "ssb-uri2": "^2.0.0"
   },
   "devDependencies": {
     "husky": "^4.3.0",
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
-    "tap-bail": "^1.0.0",
-    "tap-spec": "^5.0.0",
+    "tap-arc": "^0.3.5",
     "tape": "^5.2.2"
   },
   "husky": {

--- a/test/00-feed.js
+++ b/test/00-feed.js
@@ -9,19 +9,39 @@ const { bfeNamedTypes, bfeTypes } = bfe
 
 tape('00 feed type', function (t) {
   const values = [
-    '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519', // classic
-    'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=', // bendy-butt
+    '@FY5OG311W4j/KPh8H9B2MZt4WSziy/p+ABkKERJdujQ=.ed25519', // classic
+    'ssb:feed/classic/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=', // classic URI form
+    'ssb:feed/ed25519/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=', // classic URI form (deprecated)
     'ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=', // gabby-grove
+    // bamboo
+    'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=', // bendy-butt
     'ssb:feed/buttwoo-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=', // butt2
   ]
 
   const encoded = bfe.encode(values)
 
-  t.deepEquals(encoded[0].slice(0, 2), Buffer.from([0, 0]), 'classic feed')
-  t.deepEquals(encoded[1].slice(0, 2), Buffer.from([0, 3]), 'bendy feed')
-  t.deepEquals(encoded[2].slice(0, 2), Buffer.from([0, 1]), 'gabby grove feed')
-  t.deepEquals(encoded[3].slice(0, 2), Buffer.from([0, 4]), 'buttwoo feed')
+  t.deepEquals(
+    encoded[0].slice(0, 2),
+    Buffer.from([0, 0]),
+    'classic feed (sigil)'
+  )
+  t.deepEquals(
+    encoded[1].slice(0, 2),
+    Buffer.from([0, 0]),
+    'classic feed (uri)'
+  )
+  t.deepEquals(
+    encoded[2].slice(0, 2),
+    Buffer.from([0, 0]),
+    'classic feed (uri, deprecated)'
+  )
+  t.deepEquals(encoded[3].slice(0, 2), Buffer.from([0, 1]), 'gabby grove feed')
+  t.deepEquals(encoded[4].slice(0, 2), Buffer.from([0, 3]), 'bendy feed')
+  t.deepEquals(encoded[5].slice(0, 2), Buffer.from([0, 4]), 'buttwoo feed')
 
+  const expectedDecodedValues = values
+  expectedDecodedValues[1] = values[0] // "classic" format decodes => sigil form
+  expectedDecodedValues[2] = values[0] // "classic" format decodes => sigil form
   t.deepEquals(bfe.decode(encoded), values, 'decode works')
 
   /* unhappy paths */

--- a/test/ssb-uri.test.js
+++ b/test/ssb-uri.test.js
@@ -11,7 +11,7 @@ tape('ssb-uri encoding', function (t) {
   /* unhappy paths */
   const wrongDataLength = SSBURI.compose({
     type: 'feed',
-    format: 'ed25519',
+    format: 'classic',
     data: crypto.randomBytes(13).toString('base64'),
   })
   t.throws(() => bfe.encode(wrongDataLength), 'incorrect data length')


### PR DESCRIPTION
Update to `ssb-uri2@2.0.0` (breaking change). Fairly simple changes, no breaking change caused in/from ssb-bfe.