### PR TITLE
Add decodeTypeFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ same.
 Takes an encoded value (such as the output from `encode`) and returns the
 decoded counterparts as JavaScript primitives.
 
+### `decodeTypeFormat(input, typeName, formatName)`
+
+Takes an encoded value (such as the output from `encode`), a typeName
+and formatName and returns the decoded counterparts as JavaScript
+primitives. This is much faster than decode if you know the type.
+
 ### `bfeTypes`
 
 Returns the `bfe.json` object that can be used to look up information

--- a/index.js
+++ b/index.js
@@ -293,6 +293,9 @@ function decode(input) {
 }
 
 function decodeTypeFormat(input, typeName, formatName) {
+  const tf = input.slice(0, 2)
+  if (tf.equals(NIL_TF)) return null
+
   const type = NAMED_TYPES[typeName]
   const format = NAMED_TYPES[typeName].formats[formatName]
 

--- a/index.js
+++ b/index.js
@@ -292,9 +292,19 @@ function decode(input) {
   }
 }
 
+function decodeTypeFormat(input, typeName, formatName) {
+  const type = NAMED_TYPES[typeName]
+  const format = NAMED_TYPES[typeName].formats[formatName]
+
+  if (format.sigil || format.suffix)
+    return decoder.sigilSuffix(input, type, format)
+  else return decoder.ssbURI(input, type, format)
+}
+
 module.exports = {
   encode,
   decode,
+  decodeTypeFormat,
   bfeTypes: definitions,
   bfeNamedTypes: NAMED_TYPES,
   toTF,

--- a/test/00-feed.js
+++ b/test/00-feed.js
@@ -44,6 +44,17 @@ tape('00 feed type', function (t) {
   expectedDecodedValues[2] = values[0] // "classic" format decodes => sigil form
   t.deepEquals(bfe.decode(encoded), values, 'decode works')
 
+  t.deepEquals(
+    bfe.decodeTypeFormat(encoded[0], 'feed', 'classic'),
+    values[0],
+    'decode classic works'
+  )
+  t.deepEquals(
+    bfe.decodeTypeFormat(encoded[4], 'feed', 'bendybutt-v1'),
+    values[4],
+    'decode bendy butt works'
+  )
+
   /* unhappy paths */
   const unknownFeedId = '@' + Buffer.from('dog').toString('base64') + '.dog255'
   t.throws(

--- a/test/01-msg.js
+++ b/test/01-msg.js
@@ -22,6 +22,17 @@ tape('01 msg type', function (t) {
 
   t.deepEquals(bfe.decode(encoded), values, 'decode works')
 
+  t.deepEquals(
+    bfe.decodeTypeFormat(encoded[0], 'message', 'classic'),
+    values[0],
+    'decode classic works'
+  )
+  t.deepEquals(
+    bfe.decodeTypeFormat(encoded[1], 'message', 'bendybutt-v1'),
+    values[1],
+    'decode bendy butt works'
+  )
+
   /* unhappy paths */
   const unknownMsgId = '%' + Buffer.from('dog').toString('base64') + '.dog255'
   t.throws(() => bfe.encode(unknownMsgId), 'unknown msgId encode throws')


### PR DESCRIPTION
See also https://github.com/ssbc/ssb-uri2/pull/11

When you receive a message over the network you first validate it. This means you know that the author and previous link etc have the right format, so when converting the message in say buttwoo you can use this to make decoding a lot faster using decodeTypeFormat.

The perf script I have used to test this and the other PR:

```js
const BFE = require('.')

const key = "ssb:message/buttwoo-v1/p-I8m0DF8fywQDSjm2QQMMheN4eXe4km7Iyijp8DpS4="
const id = "ssb:feed/buttwoo-v1/OAiOTCroL1xFxoCKYaZJDTxhLOHaI1cURm_HSPvEy7s="

console.time("encode/decode")
for (var i = 0; i < 10000; ++i) {
  const eKey = BFE.encode(key)
  const eId = BFE.encode(id)

  const dKey = BFE.decodeTypeFormat(eKey, 'message', 'buttwoo-v1')
  const dId = BFE.decodeTypeFormat(eId, 'feed', 'buttwoo-v1')
  
  if (dId !== id)
    console.log("buggy")
}
console.timeEnd("encode/decode")
```

On my machine this is now 130ms, was 270ms before.